### PR TITLE
fluentbit イメージ追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM amazon/aws-for-fluent-bit:2.28.1
+
+# `/fluent-bit/etc/fluent-bit.conf` 以外のパスに置く必要がある。
+#
+# > When using a custom configuration file, you must specify a different path than the one FireLens uses. Amazon ECS
+# > reserves the `/fluent-bit/etc/fluent-bit.conf` filepath for Fluent Bit and `/fluentd/etc/fluent.conf`
+# > for Fluentd.
+# 引用: https://docs.aws.amazon.com/AmazonECS/latest/userguide/firelens-taskdef.html
+# COPY extra.conf /fluent-bit/etc/extra.conf
+
+COPY extra.conf            /fluent-bit/etc/extra.conf
+COPY output.conf           /fluent-bit/etc/output.conf
+COPY stream_processor.conf /fluent-bit/etc/stream_processor.conf
+COPY extract.lua           /fluent-bit/etc/extract.lua

--- a/extra.conf
+++ b/extra.conf
@@ -1,0 +1,41 @@
+[SERVICE]
+    Parsers_File parsers.conf
+    Streams_File stream_processor.conf
+
+# コンテナログの log キーのみ抽出
+# {"source":"stdout","log": {"method":"GET",...}} から {"level":"INFO",...} を抽出
+[FILTER]
+    Name     parser
+    Match    eventlog
+    Key_Name log
+    Parser   json
+
+# log キーの第一階層に method が存在しない場合、そのレコードは削除する
+[FILTER]
+    Name   lua
+    Match  eventlog
+    script extract.lua
+    call   validate_key
+
+# 必要キーのみ残し、他を削除する
+[FILTER]
+    Name          record_modifier
+    Match         combine.web
+    Whitelist_key method
+    Whitelist_key path
+    Whitelist_key format
+    Whitelist_key controller
+    Whitelist_key action
+    Whitelist_key status
+    Whitelist_key duration
+    Whitelist_key view
+    Whitelist_key db
+    Whitelist_key level
+    Whitelist_key user_id
+    Whitelist_key ip
+    Whitelist_key referer
+    Whitelist_key user_agent
+    Whitelist_key params
+    Whitelist_key hostname
+
+@INCLUDE output.conf

--- a/extract.lua
+++ b/extract.lua
@@ -1,0 +1,11 @@
+-- NOTE: 第一階層に method キーがあるレコードを抽出する
+-- see: https://docs.fluentbit.io/manual/pipeline/filters/lua
+function validate_key(tag, timestamp, record)
+    if record['method'] ~= nil  then
+        -- NOTE: code = 2 は元のタイムスタンプを変更しない
+        return 2, timestamp, record
+    else
+        -- NOTE: code = -1 は対象レコード削除
+        return -1, timestamp, nil
+    end
+end

--- a/output.conf
+++ b/output.conf
@@ -1,0 +1,17 @@
+# コンテナログを CloudWatch Logs に送信する
+# see: https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
+[OUTPUT]
+    Name              cloudwatch_logs
+    Match             *-firelens-*
+    region            ap-northeast-1
+    log_group_name    ${LOG_GROUP_NAME}
+    log_stream_prefix from-fluentbit-
+    log_key           log
+
+# JSONフォーマットされた Rails ログを CloudWatch Logs に送信する
+# see: https://docs.fluentbit.io/manual/pipeline/outputs/firehose
+[OUTPUT]
+    Name            kinesis_firehose
+    Match           combine.web
+    region          ap-northeast-1
+    delivery_stream ${DELIVERY_STREAM_WEB_LOG}

--- a/stream_processor.conf
+++ b/stream_processor.conf
@@ -1,0 +1,5 @@
+# NOTE: コンテナ web のみ元々のログとは別に改変したログを取得すべくストリームを作成する
+#       タグ=eventlog を付与し、以降の FILTER 時に利用する
+[STREAM_TASK]
+    Name web
+    Exec CREATE STREAM rails WITH (tag='eventlog') AS SELECT * FROM TAG:'web-firelens-*' WHERE container_name = 'web';


### PR DESCRIPTION
lograge で JSON フォーマットに整形した Rails ログ専用の Glue テーブルに対してクエリを実行できる様にすべく、 lograge で整形したログのみ抽出する fluentbit イメージを追加します。

## fluentbit の処理内容

docker/fluentbit/extra.conf にコメントを残しています。

## 構成

```mermaid
graph LR

fluentbit--1.既存コンテナログを送信-->CloudWatchLogs

fluentbit--2.JSONフォーマットRailsログ抽出-->Stream1
Stream1--3.第一階層にmethodキーがあるログのみ抽出-->Stream2
Stream2--4.必要キー以外は削除-->Stream3
Stream3-->KinesisFirehose-->S3

subgraph ECS
  rails-->fluentbit
end
```

Kinesis Firehose はログを JSON 形式から Parquet に変換し、圧縮効率を高くし、処理を円滑にします。

### コンテナログも Kinesis Firehose にする場合の注意点

Kinesis Firehose 1つ当たり、参照できる Glue テーブルスキーマは 1つなので、 コンテナログについては構成で記載の Kinesis Firehose とは別のログキーの構成になる為、分ける必要があります。 今回は利用しないので、考慮しません。

## extract.lua で log キーの第一階層に method があるかどうかで判定する理由

```
{
  "log": "\{"method":"GET",...\}"
```

lograge で JSON フォーマットされた Rails ログはコンテナログの log キーに JSON 形式で出力されます。 上記以外の rails ログは JSON 形式でなくテキスト形式でログ出力されます。

「第一階層」に対して method キーがあるかで判定しているのは
POST メソッドで param に method キーが含まれる場合で必要なログキーとして判定されないようにする為です。

```
{
  "log": "\{\"level\":\"info\",...,\"params\":{\"method\":\"dummy\"}\}"
```
