### PR TITLE
GitHub Actions で fluentbit テスト追加

### DIFF
--- a/.github/workflows/test_fluentbit.yml
+++ b/.github/workflows/test_fluentbit.yml
@@ -1,0 +1,106 @@
+name: test_fluentbit
+
+on:
+  push:
+
+jobs:
+  test_fluentbit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+
+      # テスト用イメージビルド
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ github.ref }}-${{ github.sha }}
+            ${{ github.ref }}
+            refs/head/main
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build a Docker image for testing
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          builder: ${{ steps.buildx.outputs.name }}
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          outputs: type=docker # GitHub Actions 上のローカルに build し、以降 step でイメージを参照できる様にする
+          tags: test-fluentbit:latest
+
+      - name: fluentbit 設定ファイル構文チェック
+        run: >
+          docker run --rm
+          -e DELIVERY_STREAM=dummy
+          -e DELIVERY_STREAM_EVENT_LOG=dummy
+          test-fluentbit:latest
+          /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/extra.conf --dry-run
+
+      - name: fluentbit コンテナへ外部から http 経由でアクセスすべく、docker network を作成
+        run: docker network create actions
+
+      # テスト用 fluentbit コンテナ起動
+      # 以降、このテスト用 fluentbit コンテナを利用しテストを実施する
+      - name: run fluentbit for testing
+        run: >
+          docker run --rm -d
+          --name fluentbit
+          --network actions
+          -v /tmp:/tmp
+          -v $(pwd)/test/output.conf:/fluent-bit/etc/output.conf
+          -v $(pwd)/test/test.conf:/fluent-bit/etc/test.conf
+          test-fluentbit:latest
+          /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/test.conf
+
+      # NOTE: http://fluentbit:9880/web-firelens-dummy に対して curl することで
+      #       tag=web-firelens-dummy を付与したログを fluentbit に POST できる。
+      - name: fluentbit コンテナへ Rails コンテナログを http 経由で POST する
+        run: >
+          docker run --rm
+          --network actions
+          --link fluentbit:fluentbit
+          -v $(pwd)/test/web_container.log:/tmp/web_container.log
+          curlimages/curl:latest -v -d @/tmp/web_container.log -XPOST -H "content-type: application/json"
+          http://fluentbit:9880/web-firelens-dummy
+      - name: コンテナログファイルが生成されるまで待機する。生成されない場合、テスト失敗となる
+        # NOTE: web-firelens-dummy タグでリクエストすると web_firelens_dummy というファイル名で生成される
+        run: while [ ! -e /tmp/web_firelens_dummy ]; do sleep 1; done
+      - name: Rails コンテナログが改変されず出力されること。実値と予測値が一致しない場合、テスト失敗とし異常終了する
+        # NOTE: fluentbit 経由で出力されるログの JSON のキーは毎回順不同な為、 `--sort-keys` でキーを昇順にソートしています。
+        run: |
+          diff -q \
+          <(sed 's|web_firelens_dummy: ||g' /tmp/web_firelens_dummy | jq -r --sort-keys '.[1]') \
+          <(cat ./test/web_container.log | jq --sort-keys .)
+
+      # NOTE: http://fluentbit:9880/eventlog に対して curl することで
+      #       tag=eventlog を付与したログを fluentbit に POST できる。
+      - name: fluentbit コンテナへ lograge で JSON フォーマットされた Rails ログでないログを http 経由で POST する
+        run: >
+          docker run --rm
+          --network actions
+          --link fluentbit:fluentbit
+          -v $(pwd)/test/no_target_event.log:/tmp/no_target_event.log
+          curlimages/curl:latest -v -d @/tmp/no_target_event.log -XPOST -H "content-type: application/json"
+          http://fluentbit:9880/eventlog
+      - name: ユーザ行動ログが含まれる場合、最低でも 5 秒以内でログファイルが生成される為、5 秒間待機する
+        run: sleep 5
+      - name: ユーザ行動抽出対象でないログである場合、ログファイルが生成されない。生成される場合テスト失敗とし異常終了する
+        run: if [ -e /tmp/eventlog ]; then exit 1; fi
+
+      - name: fluentbit コンテナへ lograge で JSON フォーマットされた Rails ログを http 経由で POST する
+        run: >
+          docker run --rm
+          --network actions
+          --link fluentbit:fluentbit
+          -v $(pwd)/test/event.log:/tmp/event.log
+          curlimages/curl:latest -v -d @/tmp/event.log -XPOST -H "content-type: application/json"
+          http://fluentbit:9880/eventlog
+      - name: ユーザ行動ログファイルで生成されるまで待機する。生成されない場合、テスト失敗となる
+        run: while [ ! -e /tmp/eventlog ]; do sleep 1; done
+      # NOTE: ユーザ行動ログを含むログの場合、 expect filter plugin で抽出ログを検証する為、出力ログファイルの検証はしない

--- a/extra.conf
+++ b/extra.conf
@@ -3,7 +3,7 @@
     Streams_File stream_processor.conf
 
 # コンテナログの log キーのみ抽出
-# {"source":"stdout","log": {"method":"GET",...}} から {"level":"INFO",...} を抽出
+# {"source":"stdout","log": {"method":"GET",...}} から {"method":"GET",...} を抽出
 [FILTER]
     Name     parser
     Match    eventlog

--- a/test/event.log
+++ b/test/event.log
@@ -1,0 +1,1 @@
+{"source":"stdout","log":"{\"method\":\"GET\",\"path\":\"/sre/boshuchu\",\"format\":\"html\",\"controller\":\"SRE::BoshuchuController\",\"action\":\"show\",\"status\":200,\"duration\":25.11,\"view\":0.73,\"level\":\"info\",\"user_id\":null,\"ip\":null,\"referer\":null,\"user_agent\":null,\"time\":\"2022-09-22T18:21:19+09:00\",\"params\":{}}"}

--- a/test/no_target_event.log
+++ b/test/no_target_event.log
@@ -1,0 +1,1 @@
+{"source":"stdout","log":"I, [2022-09-22T09:21:19.552353 #1]  INFO -- : Started GET \"/healthcheck\" for 130.176.189.6 at 2022-09-22 09:21:19 +0000"}

--- a/test/output.conf
+++ b/test/output.conf
@@ -1,0 +1,8 @@
+[OUTPUT]
+    Name file
+    Match *
+    Path /tmp/
+
+[OUTPUT]
+    Name stdout
+    Match *

--- a/test/test.conf
+++ b/test/test.conf
@@ -1,0 +1,26 @@
+[INPUT]
+    name http
+
+@INCLUDE extra.conf
+
+[FILTER]
+    name expect
+    match eventlog
+
+    key_val_eq method GET
+    key_val_eq path /sre/boshuchu
+    key_val_eq format html
+    key_val_eq controller SRE::BoshuchuController
+    key_val_eq action show
+    key_val_eq status 200
+    key_val_eq duration 25.11
+    key_val_eq view 0.73
+    key_val_eq level info
+    key_val_eq user_id null
+    key_val_eq ip null
+    key_val_eq referer null
+    key_val_eq user_agent null
+    key_val_eq time 2022-09-22T18:21:19+09:00
+    key_val_eq params {}
+
+    action exit

--- a/test/web_container.log
+++ b/test/web_container.log
@@ -1,0 +1,1 @@
+{"source":"stdout","log":"I, [2022-09-29T07:43:57.152386 #1]  INFO -- : Processing by Sre::BoshuchuController#index as HTML"}


### PR DESCRIPTION
fluentbit で以下テストを追加します。

* 既存のコンテナログは特に処理を変更されず、ログ送信されること
* 既存のコンテナログから lograge でJSONフォーマットされた Rails ログを含む場合、ログの抽出対象としてログが出力されること
* 既存のコンテナログから lograge でJSONフォーマットされた Rails ログを含まない場合、そのログ自体が削除されること

## テスト実施方法

テストの工夫点を以下にまとめます。

### output に Kinesis Firehose が設定されているとエラーが発生するので output 上書きで回避

テスト時には Kinesis への接続ができずエラーとなる為、
`docker/fluentbit/test/output.conf` で上書きしエラーを回避しています。

```
        run: |
          docker run --rm -d \
          -v $(pwd)/docker/fluentbit/test/output.conf:/fluent-bit/etc/output.conf \
          test-fluentbit:latest \
```

### INPUT は http plugin を採用する

[http input plugin](https://docs.fluentbit.io/manual/pipeline/inputs/http) を使用することで fluentbit を http 経由で任意のタグでログを POST できる様になります。

これにより複数のログのテストを実施できる様になります。

* docker/fluentbit/test/test.conf extra.conf をラップし http input plugin を設定しています。
```
[INPUT]
    Name http

@include extra.conf
```

[dummy input plugin](https://docs.fluentbit.io/manual/pipeline/inputs/dummy) は、テスト毎に conf ファイルを読み込ませ直す必要があり、 fluentbit を起動する必要があり、実行時間が掛かりコスト増です。 [tail input plugin](https://docs.fluentbit.io/manual/pipeline/inputs/tail) は、 上記同様、テスト毎に conf ファイルを読み込ませる必要があります。 [tcp input plugin](https://docs.fluentbit.io/manual/pipeline/inputs/tcp) は、外部からタグ指定できません。

### GitHub Actions 上で docker run で起動したコンテナにアクセスする為に network 作成

GitHub Actions 上で `docker run` で起動したコンテナは 127.0.0.1 ではアクセスできません。 その為、 docker network を作成しその network 上から
`curlimages/curl:latest` 経由で curl を fluentbit コンテナに対し実行しています。

```
      - name: fluentbit コンテナへ外部から http 経由でアクセスすべく、docker network を作成
        run: docker network create actions

      - name: run fluentbit for testing
        run: >
          docker run --rm -d
          --name fluentbit
          --network actions
          ...
          test-fluentbit:latest
          /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/test.conf

      # NOTE: http://fluentbit:9880/web-firelens-dummy に対して curl することで
      #       tag=web-firelens-dummy を付与したログを fluentbit に POST できる。
      - name: fluentbit コンテナへコンテナログを http 経由で POST する
        run: >
          docker run --rm
          --network actions
          --link fluentbit:fluentbit
          -v $(pwd)/docker/fluentbit/test/web_container.log:/tmp/web_container.log
          curlimages/curl:latest -v -d @/tmp/web_container.log -XPOST -H "content-type: application/json"
          http://fluentbit:9880/web-firelens-dummy
```

### expect filter plugin で lograge で JSON フォーマットされた Rails ログが取得できているかチェック

[expect filter plugin](https://docs.fluentbit.io/manual/pipeline/filters/expect) を使用し extra.conf でコンテナログから抽出した lograge で整形された JSONフォーマットされた Rails ログを expect で個々のキー値を検証します。
`action exit` でいずれかのチェックで失敗した場合、異常終了となります。

### fluentbit が意図した振る舞いをしているかは出力するログファイルの内容を照合する

expect filter plugin
は、ログが含まれるログについてのチェックで使用しています。
それ以外のユーザ行動ログが含まれないログについては fluentbit
経由で出力したログファイルの内容を照合することで fluentbit
が意図通りの振る舞いかをテストします。

以下は通常のコンテナログが改変されずにログ出力されるかのテストです。
```
      # NOTE: http://fluentbit:9880/web-firelens-dummy に対して curl することで
      #       tag=web-firelens-dummy を付与したログを fluentbit に POST できる。
      - name: fluentbit コンテナへ Rails コンテナログを http 経由で POST する
        run: >
          docker run --rm
          ...
          curlimages/curl:latest -v -d @/tmp/web_container.log -XPOST -H "content-type: application/json"
          http://fluentbit:9880/web-firelens-dummy
      - name: コンテナログファイルが生成されるまで待機する。生成されない場合、テスト失敗となる
        # NOTE: web-firelens-dummy タグでリクエストすると web_firelens_dummy というファイル名で生成される
        run: while [ ! -e /tmp/web_firelens_dummy ]; do sleep 1; done
      - name: Rails コンテナログが改変されず出力されること。実値と予測値が一致しない場合、テスト失敗とし異常終了する
        # NOTE: fluentbit 経由で出力されるログの JSON のキーは毎回順不同な為、 `--sort-keys` でキーを昇順にソートしています。
        run: |
          diff -q \
          <(sed 's|web_firelens_dummy: ||g' /tmp/web_firelens_dummy | jq -r --sort-keys '.[1]') \
          <(cat ./docker/fluentbit/test/web_container.log | jq --sort-keys .)
```

`/tmp/web_firelens_dummy` に出力されるログは以下の通りです。

```
web_firelens_dummy: [1652281548.113955421, {"source":"stdout","log":"{\"level\":\"INFO\",\"timestamp\":\"2022-03-17T04:15:30+00:00\",\"params\":{\"events\":[{\"screen_name\":\"ishicome_questions\",\"action_name\":\"ishicome_questions_detail\"}]}}"}]
```

timestamp は変更されてしまう為、
第二要素を `{"source":"stdout","log": ...}` 比較対象としています。 比較時に json は毎回順不同になる為、 `--sort-keys` でキーを昇順 (a→z) に並べています。

```
        run: |
          diff -q \
          <(sed 's|web_firelens_dummy: ||g' /tmp/web_firelens_dummy | jq -r --sort-keys '.[1]') \
          <(cat ./docker/fluentbit/test/web_container.log | jq --sort-keys .)
```